### PR TITLE
Wire up CircleCI: cached build + test jobs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,48 @@ jobs:
       - image: cimg/elixir:1.18.4-erlang-26.2.1
     steps:
       - checkout
+      # cache key: bump the v1 prefix when the docker image (Elixir/OTP) changes;
+      # the PLT lives under _build/dev/dialyxir_*.plt and is keyed to mix.lock
+      - restore_cache:
+          keys:
+            - v1-build-{{ checksum "mix.lock" }}
+            - v1-build-
       - run: mix deps.get
       - run: mix deps.compile
       - run: mix deps.audit
       - run: mix sobelow --config .sobelow-conf
+      # build the PLT separately so it is cached even when the analysis
+      # step below fails with findings
+      - run: mix dialyzer --plt
+      - save_cache:
+          key: v1-build-{{ checksum "mix.lock" }}
+          paths:
+            - deps
+            - _build
+            - ~/.mix
       - run: mix dialyzer
+  test:
+    environment:
+      MIX_ENV: test
+    docker:
+      - image: cimg/elixir:1.18.4-erlang-26.2.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-test-{{ checksum "mix.lock" }}
+            - v1-test-
+      - run: mix deps.get
+      - run: mix deps.compile
+      - run: mix test
+      - save_cache:
+          key: v1-test-{{ checksum "mix.lock" }}
+          paths:
+            - deps
+            - _build
+            - ~/.mix
 workflows:
   test:
     jobs:
       - build
+      - test


### PR DESCRIPTION
## Summary

Expands the CircleCI pipeline to actually run the test suite and cache builds, using [Audian/magpie](https://github.com/Audian/magpie)'s `.circleci/config.yml` as the base, adapted for a pure library (no database).

## Changes

- **`test` job (new):** runs `mix test` (33 tests) under `MIX_ENV=test` — previously nothing ran the suite in CI.
- **`build` job:** adds `restore_cache`/`save_cache` (keyed on `mix.lock`) and splits `mix dialyzer --plt` from `mix dialyzer` so the PLT is cached even when analysis reports findings. Retains `deps.audit`, `sobelow`, and `dialyzer`.
- **Workflow** now runs `build` + `test`.

## Adaptations from magpie

- **No Postgres / `dockerize` wait** — chronology is a pure library with no Ecto/DB.
- **Build job runs in the default `dev` env** (not `MIX_ENV=circleci`) because chronology's `dialyxir`/`sobelow`/`mix_audit` are `only: [:dev]`; a `circleci` env would leave those mix tasks unavailable.
- Image kept at magpie's `cimg/elixir:1.18.4-erlang-26.2.1` (verified present on Docker Hub).

## Verification (locally, dev + test envs)

- `mix test` — 33 tests, 0 failures
- `mix deps.audit` — no vulnerabilities
- `mix sobelow --config .sobelow-conf` — clean (exit 0)
- `mix dialyzer` — 0 errors

## Follow-up needed (outside this repo)

CircleCI must be **following this repo** for the pipeline to run and report a status check on PRs — that's a one-time setup in the CircleCI app (Projects → set up `chronology`). Once it reports, consider adding the CircleCI check to the branch ruleset's required checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test execution to the continuous integration workflow.
  * Improved dependency caching to help make builds and tests more efficient.
  * Added dedicated Dialyzer setup and analysis steps to improve static checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->